### PR TITLE
Add DataSource interface for dependency inversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # preselect
+
+A Go application that scans CSV, JSON, and YAML files for user-defined keywords using string similarity metrics. The project is structured with a layered architecture consisting of API, Business, and Data layers.
+
+This repository currently contains the basic skeleton of the application.
+
+## Layers
+
+- **API Layer**: Handles configuration and orchestrates application flow.
+- **Business Layer**: Contains similarity checks, result processing, and a `DataSource` interface for pluggable inputs.
+- **Data Layer**: Reads data from files in chunks for scalable processing.
+
+## Usage
+
+The project is in its early stages and presently only provides a scaffold for future development.
+

--- a/api/app.go
+++ b/api/app.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"preselect/business"
+	"preselect/data"
+)
+
+// Config holds application configuration options.
+type Config struct {
+	// Placeholder for configuration fields
+}
+
+// App wires configuration with the business layer.
+type App struct {
+	scanner business.Scanner
+	cfg     Config
+}
+
+// New creates a new App instance.
+func New(cfg Config) *App {
+	source := data.NewLoader()
+	return &App{
+		scanner: business.NewScanner(source),
+		cfg:     cfg,
+	}
+}
+
+// Run starts the application.
+func (a *App) Run() error {
+	return a.scanner.Scan(nil)
+}

--- a/business/datasource.go
+++ b/business/datasource.go
@@ -1,0 +1,12 @@
+package business
+
+// Entry represents a single piece of data from a source with its origin path.
+type Entry struct {
+	Value string
+	Path  []string
+}
+
+// DataSource abstracts the retrieval of sequential entries.
+type DataSource interface {
+	Next() (Entry, error)
+}

--- a/business/scanner.go
+++ b/business/scanner.go
@@ -1,0 +1,29 @@
+package business
+
+import "io"
+
+// Scanner coordinates similarity checks on data provided by a DataSource.
+type Scanner struct {
+	source DataSource
+}
+
+// NewScanner creates a new Scanner instance.
+func NewScanner(source DataSource) Scanner {
+	return Scanner{source: source}
+}
+
+// Scan searches for keywords in the provided source.
+func (s Scanner) Scan(keywords []string) error {
+	for {
+		entry, err := s.source.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		_ = entry // placeholder for processing logic
+	}
+	_ = keywords // reference to avoid unused warning
+	return nil
+}

--- a/cmd/preselect/main.go
+++ b/cmd/preselect/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+
+	"preselect/api"
+)
+
+func main() {
+	app := api.New(api.Config{})
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/data/loader.go
+++ b/data/loader.go
@@ -1,0 +1,21 @@
+package data
+
+import (
+	"io"
+
+	"preselect/business"
+)
+
+// Loader retrieves file data entry by entry.
+type Loader struct{}
+
+// NewLoader creates a new Loader instance.
+func NewLoader() Loader {
+	return Loader{}
+}
+
+// Next returns the next entry from the source.
+func (l Loader) Next() (business.Entry, error) {
+	// Placeholder for loader logic
+	return business.Entry{}, io.EOF
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module preselect
+
+go 1.20


### PR DESCRIPTION
## Summary
- Define `Entry` struct and `DataSource` interface in business layer
- Update scanner to consume sequential entries and expose dependency inversion
- Implement loader to satisfy `DataSource` and wire through API layer
- Document new `DataSource` abstraction in README

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c1a12602688333aa5c743deaf2af4a