### PR TITLE
Implement token-based text file DataSource

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -3,6 +3,7 @@ package api
 import (
 	"preselect/business"
 	"preselect/data"
+	"strings"
 )
 
 // Config holds application configuration options.
@@ -18,7 +19,7 @@ type App struct {
 
 // New creates a new App instance.
 func New(cfg Config) *App {
-	source := data.NewLoader()
+	source := data.NewLoader(strings.NewReader(""), nil)
 	return &App{
 		scanner: business.NewScanner(source),
 		cfg:     cfg,

--- a/data/loader.go
+++ b/data/loader.go
@@ -1,21 +1,108 @@
 package data
 
 import (
+	"bufio"
 	"io"
+	"strconv"
+	"strings"
 
 	"preselect/business"
 )
 
-// Loader retrieves file data entry by entry.
-type Loader struct{}
-
-// NewLoader creates a new Loader instance.
-func NewLoader() Loader {
-	return Loader{}
+// Loader retrieves file data entry by entry using token-based scanning.
+type Loader struct {
+	reader      *bufio.Reader
+	delimiters  map[rune]struct{}
+	token       []rune
+	inToken     bool
+	tokenStart  int64
+	position    int64
+	tokenNumber int
+	line        int
+	eof         bool
 }
 
-// Next returns the next entry from the source.
-func (l Loader) Next() (business.Entry, error) {
-	// Placeholder for loader logic
-	return business.Entry{}, io.EOF
+// NewLoader creates a new Loader. If r is nil, an empty reader is used. Delimiters
+// default to space and newline when none are provided.
+func NewLoader(r io.Reader, delimiters []rune) *Loader {
+	if r == nil {
+		r = strings.NewReader("")
+	}
+	if len(delimiters) == 0 {
+		delimiters = []rune{' ', '\n'}
+	}
+	delimMap := make(map[rune]struct{}, len(delimiters))
+	for _, d := range delimiters {
+		delimMap[d] = struct{}{}
+	}
+	return &Loader{
+		reader:     bufio.NewReader(r),
+		delimiters: delimMap,
+		line:       1,
+	}
+}
+
+// Next returns the next entry from the source based on tokenization.
+func (l *Loader) Next() (business.Entry, error) {
+	for {
+		if l.eof {
+			if l.inToken {
+				l.tokenNumber++
+				entry := business.Entry{
+					Value: string(l.token),
+					Path: []string{
+						strconv.Itoa(l.tokenNumber),
+						strconv.FormatInt(l.tokenStart, 10),
+						strconv.Itoa(l.line),
+					},
+				}
+				l.token = nil
+				l.inToken = false
+				return entry, nil
+			}
+			return business.Entry{}, io.EOF
+		}
+
+		r, size, err := l.reader.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				l.eof = true
+				continue
+			}
+			return business.Entry{}, err
+		}
+
+		currentPos := l.position
+		l.position += int64(size)
+
+		if _, ok := l.delimiters[r]; ok {
+			if l.inToken {
+				l.tokenNumber++
+				entry := business.Entry{
+					Value: string(l.token),
+					Path: []string{
+						strconv.Itoa(l.tokenNumber),
+						strconv.FormatInt(l.tokenStart, 10),
+						strconv.Itoa(l.line),
+					},
+				}
+				l.token = nil
+				l.inToken = false
+				if r == '\n' {
+					l.line++
+				}
+				return entry, nil
+			}
+			if r == '\n' {
+				l.line++
+			}
+			continue
+		}
+
+		if !l.inToken {
+			l.inToken = true
+			l.tokenStart = currentPos
+		}
+		l.token = append(l.token, r)
+	}
 }

--- a/data/loader_test.go
+++ b/data/loader_test.go
@@ -1,0 +1,41 @@
+package data
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestLoaderTokenization(t *testing.T) {
+	text := "hello world\nnext line"
+	l := NewLoader(strings.NewReader(text), nil)
+
+	tests := []struct {
+		value string
+		path  []string
+	}{
+		{"hello", []string{"1", "0", "1"}},
+		{"world", []string{"2", "6", "1"}},
+		{"next", []string{"3", "12", "2"}},
+		{"line", []string{"4", "17", "2"}},
+	}
+
+	for i, tt := range tests {
+		entry, err := l.Next()
+		if err != nil {
+			t.Fatalf("unexpected error on token %d: %v", i, err)
+		}
+		if entry.Value != tt.value {
+			t.Fatalf("token %d value = %q, want %q", i, entry.Value, tt.value)
+		}
+		for j, p := range tt.path {
+			if entry.Path[j] != p {
+				t.Fatalf("token %d path[%d] = %q, want %q", i, j, entry.Path[j], p)
+			}
+		}
+	}
+
+	if _, err := l.Next(); err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add text-file DataSource that scans tokens with configurable delimiters
- update application wiring to use new loader
- cover tokenization behavior with unit tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c1a591bba483338553a45b27ef33d5