### PR TITLE
Add configurable processor interface and CSV implementation

### DIFF
--- a/api/processor/processor.go
+++ b/api/processor/processor.go
@@ -1,0 +1,20 @@
+package processor
+
+// SimilarityMetric defines a function to measure the similarity between two strings.
+type SimilarityMetric func(a, b string) float64
+
+// Config contains options for setting up a Processor.
+type Config struct {
+	Metric    SimilarityMetric
+	Keywords  []string
+	Threshold float64
+}
+
+// Processor evaluates entries using a similarity metric and stores those
+// that meet a configured threshold. Implementations determine how kept
+// entries are stored.
+type Processor interface {
+	// Process evaluates the entry. It returns true if the entry was kept
+	// and stored, along with any error encountered during processing.
+	Process(entry string) (bool, error)
+}

--- a/business/csv_processor.go
+++ b/business/csv_processor.go
@@ -1,0 +1,59 @@
+package business
+
+import (
+	"encoding/csv"
+	"os"
+
+	"preselect/api/processor"
+)
+
+// CSVProcessor implements processor.Processor by storing kept entries in a CSV file.
+type CSVProcessor struct {
+	cfg    processor.Config
+	writer *csv.Writer
+	file   *os.File
+}
+
+var _ processor.Processor = (*CSVProcessor)(nil)
+
+// NewCSVProcessor creates a CSVProcessor writing kept entries to the given file path.
+func NewCSVProcessor(cfg processor.Config, filePath string) (*CSVProcessor, error) {
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &CSVProcessor{
+		cfg:    cfg,
+		writer: csv.NewWriter(f),
+		file:   f,
+	}, nil
+}
+
+// Process evaluates an entry against configured keywords using the provided
+// similarity metric. Entries meeting or exceeding the threshold are written to
+// the CSV file. It returns true if the entry was kept.
+func (p *CSVProcessor) Process(entry string) (bool, error) {
+	for _, k := range p.cfg.Keywords {
+		if p.cfg.Metric(entry, k) >= p.cfg.Threshold {
+			if err := p.writer.Write([]string{entry}); err != nil {
+				return false, err
+			}
+			p.writer.Flush()
+			if err := p.writer.Error(); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Close releases the underlying file resources.
+func (p *CSVProcessor) Close() error {
+	p.writer.Flush()
+	if err := p.writer.Error(); err != nil {
+		_ = p.file.Close()
+		return err
+	}
+	return p.file.Close()
+}


### PR DESCRIPTION
## Summary
- define processor interface with configurable similarity metric, keywords and threshold
- implement CSV-based processor storing kept entries that meet threshold

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c1a8e5de8c8333a291287936cafc6d