### PR TITLE
feat: add configurable extension scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,17 @@ This repository currently contains the basic skeleton of the application.
 
 ## Usage
 
-The project is in its early stages and presently only provides a scaffold for future development.
+`preselect` scans a directory for files whose extensions are associated with a data
+source. Mappings are supplied on the command line using the `-ext` flag:
+
+```
+preselect -dir ./data -ext txt=,;
+```
+
+The above command scans `./data` and tokenizes `.txt` files using commas and
+semicolons as delimiters. When no mapping is provided for `txt` files, they are
+tokenized using spaces and newlines by default.
+
+The project is in its early stages and presently only provides a scaffold for
+future development.
 

--- a/api/app.go
+++ b/api/app.go
@@ -1,32 +1,55 @@
 package api
 
 import (
+	"io"
+
+	"preselect/api/processor"
 	"preselect/business"
 	"preselect/data"
-	"strings"
 )
 
 // Config holds application configuration options.
 type Config struct {
-	// Placeholder for configuration fields
+	Root      string
+	ExtMap    map[string]SourceFactory
+	Processor processor.Processor
 }
 
 // App wires configuration with the business layer.
 type App struct {
-	scanner business.Scanner
-	cfg     Config
+	cfg Config
 }
 
 // New creates a new App instance.
 func New(cfg Config) *App {
-	source := data.NewLoader(strings.NewReader(""), nil)
-	return &App{
-		scanner: business.NewScanner(source),
-		cfg:     cfg,
-	}
+	return &App{cfg: cfg}
 }
 
 // Run starts the application.
 func (a *App) Run() error {
-	return a.scanner.Scan(nil)
+	extMap := make(map[string]SourceFactory)
+	for k, v := range a.cfg.ExtMap {
+		extMap[k] = v
+	}
+	if _, ok := extMap["txt"]; !ok {
+		extMap["txt"] = func(r io.Reader) business.DataSource {
+			return data.NewLoader(r, nil)
+		}
+	}
+
+	root := a.cfg.Root
+	if root == "" {
+		root = "."
+	}
+
+	proc := a.cfg.Processor
+	if proc == nil {
+		proc = noopProcessor{}
+	}
+
+	return ScanDirectory(root, extMap, proc)
 }
+
+type noopProcessor struct{}
+
+func (noopProcessor) Process(string) (bool, error) { return false, nil }

--- a/cmd/preselect/main.go
+++ b/cmd/preselect/main.go
@@ -1,13 +1,58 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"io"
 	"log"
+	"strings"
 
 	"preselect/api"
+	"preselect/business"
+	"preselect/data"
 )
 
+type extMapFlag map[string][]rune
+
+func (e *extMapFlag) String() string {
+	var parts []string
+	for k, v := range *e {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, string(v)))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (e *extMapFlag) Set(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	ext := strings.TrimPrefix(strings.ToLower(parts[0]), ".")
+	var delims []rune
+	if len(parts) == 2 {
+		delims = []rune(parts[1])
+	}
+	if *e == nil {
+		*e = make(map[string][]rune)
+	}
+	(*e)[ext] = delims
+	return nil
+}
+
 func main() {
-	app := api.New(api.Config{})
+	var root string
+	mappings := make(extMapFlag)
+
+	flag.StringVar(&root, "dir", ".", "directory to scan")
+	flag.Var(&mappings, "ext", "extension to delimiters mapping (e.g. -ext txt=,;)")
+	flag.Parse()
+
+	cfg := api.Config{Root: root, ExtMap: map[string]api.SourceFactory{}}
+	for ext, delims := range mappings {
+		d := delims
+		cfg.ExtMap[ext] = func(r io.Reader) business.DataSource {
+			return data.NewLoader(r, d)
+		}
+	}
+
+	app := api.New(cfg)
 	if err := app.Run(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- allow configuring extension-to-source mappings via command line flags
- add default token-based scanner for txt files and allow overrides
- document flag usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c1af3d18548333994f781dbb25be7d