### PR TITLE
Add configurable CSV data source

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -36,6 +36,11 @@ func (a *App) Run() error {
 			return data.NewLoader(r, nil)
 		}
 	}
+	if _, ok := extMap["csv"]; !ok {
+		extMap["csv"] = func(r io.Reader) business.DataSource {
+			return data.NewCSVLoader(r, ',', '"')
+		}
+	}
 
 	root := a.cfg.Root
 	if root == "" {

--- a/cmd/preselect/main.go
+++ b/cmd/preselect/main.go
@@ -12,12 +12,21 @@ import (
 	"preselect/data"
 )
 
-type extMapFlag map[string][]rune
+type extConfig struct {
+	delims []rune
+	quote  rune
+}
+
+type extMapFlag map[string]extConfig
 
 func (e *extMapFlag) String() string {
 	var parts []string
 	for k, v := range *e {
-		parts = append(parts, fmt.Sprintf("%s=%s", k, string(v)))
+		s := string(v.delims)
+		if v.quote != 0 {
+			s += ":" + string(v.quote)
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", k, s))
 	}
 	return strings.Join(parts, ",")
 }
@@ -26,13 +35,21 @@ func (e *extMapFlag) Set(value string) error {
 	parts := strings.SplitN(value, "=", 2)
 	ext := strings.TrimPrefix(strings.ToLower(parts[0]), ".")
 	var delims []rune
+	var quote rune
 	if len(parts) == 2 {
-		delims = []rune(parts[1])
+		dq := strings.SplitN(parts[1], ":", 2)
+		delims = []rune(dq[0])
+		if len(dq) == 2 {
+			q := []rune(dq[1])
+			if len(q) > 0 {
+				quote = q[0]
+			}
+		}
 	}
 	if *e == nil {
-		*e = make(map[string][]rune)
+		*e = make(map[string]extConfig)
 	}
-	(*e)[ext] = delims
+	(*e)[ext] = extConfig{delims: delims, quote: quote}
 	return nil
 }
 
@@ -41,14 +58,30 @@ func main() {
 	mappings := make(extMapFlag)
 
 	flag.StringVar(&root, "dir", ".", "directory to scan")
-	flag.Var(&mappings, "ext", "extension to delimiters mapping (e.g. -ext txt=,;)")
+	flag.Var(&mappings, "ext", "extension configuration (e.g. -ext txt=,; -ext csv=;:\" )")
 	flag.Parse()
 
 	cfg := api.Config{Root: root, ExtMap: map[string]api.SourceFactory{}}
-	for ext, delims := range mappings {
-		d := delims
-		cfg.ExtMap[ext] = func(r io.Reader) business.DataSource {
-			return data.NewLoader(r, d)
+	for ext, conf := range mappings {
+		c := conf
+		switch ext {
+		case "csv":
+			delim := ','
+			if len(c.delims) > 0 {
+				delim = c.delims[0]
+			}
+			quote := '"'
+			if c.quote != 0 {
+				quote = c.quote
+			}
+			cfg.ExtMap[ext] = func(r io.Reader) business.DataSource {
+				return data.NewCSVLoader(r, delim, quote)
+			}
+		default:
+			d := c.delims
+			cfg.ExtMap[ext] = func(r io.Reader) business.DataSource {
+				return data.NewLoader(r, d)
+			}
 		}
 	}
 

--- a/data/csv.go
+++ b/data/csv.go
@@ -1,0 +1,135 @@
+package data
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+
+	"preselect/business"
+)
+
+// CSVLoader retrieves CSV data entry by entry.
+type CSVLoader struct {
+	reader  *bufio.Reader
+	delim   rune
+	quote   rune
+	row     int
+	col     int
+	inQuote bool
+	token   []rune
+	eof     bool
+}
+
+// NewCSVLoader creates a new CSVLoader. If r is nil, an empty reader is used.
+// Delim defaults to comma and quote to double quote when zero values are provided.
+func NewCSVLoader(r io.Reader, delim, quote rune) *CSVLoader {
+	if r == nil {
+		r = strings.NewReader("")
+	}
+	if delim == 0 {
+		delim = ','
+	}
+	if quote == 0 {
+		quote = '"'
+	}
+	return &CSVLoader{
+		reader: bufio.NewReader(r),
+		delim:  delim,
+		quote:  quote,
+		row:    1,
+	}
+}
+
+// Next returns the next cell from the CSV source.
+func (l *CSVLoader) Next() (business.Entry, error) {
+	for {
+		if l.eof {
+			if l.token != nil {
+				l.col++
+				entry := business.Entry{
+					Value: string(l.token),
+					Path:  []string{strconv.Itoa(l.row), strconv.Itoa(l.col)},
+				}
+				l.token = nil
+				return entry, nil
+			}
+			return business.Entry{}, io.EOF
+		}
+
+		r, _, err := l.reader.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				l.eof = true
+				continue
+			}
+			return business.Entry{}, err
+		}
+
+		if l.inQuote {
+			if r == l.quote {
+				next, _, err := l.reader.ReadRune()
+				if err == nil {
+					if next == l.quote {
+						l.token = append(l.token, l.quote)
+						continue
+					}
+					l.reader.UnreadRune()
+				} else if err == io.EOF {
+					l.eof = true
+				} else {
+					return business.Entry{}, err
+				}
+				l.inQuote = false
+				continue
+			}
+			l.token = append(l.token, r)
+			continue
+		}
+
+		switch r {
+		case l.quote:
+			l.inQuote = true
+		case l.delim:
+			l.col++
+			entry := business.Entry{
+				Value: string(l.token),
+				Path:  []string{strconv.Itoa(l.row), strconv.Itoa(l.col)},
+			}
+			l.token = nil
+			return entry, nil
+		case '\n':
+			l.col++
+			entry := business.Entry{
+				Value: string(l.token),
+				Path:  []string{strconv.Itoa(l.row), strconv.Itoa(l.col)},
+			}
+			l.token = nil
+			l.row++
+			l.col = 0
+			return entry, nil
+		case '\r':
+			next, _, err := l.reader.ReadRune()
+			if err == nil {
+				if next != '\n' {
+					l.reader.UnreadRune()
+				}
+			} else if err != io.EOF {
+				return business.Entry{}, err
+			} else {
+				l.eof = true
+			}
+			l.col++
+			entry := business.Entry{
+				Value: string(l.token),
+				Path:  []string{strconv.Itoa(l.row), strconv.Itoa(l.col)},
+			}
+			l.token = nil
+			l.row++
+			l.col = 0
+			return entry, nil
+		default:
+			l.token = append(l.token, r)
+		}
+	}
+}

--- a/data/csv_test.go
+++ b/data/csv_test.go
@@ -1,0 +1,40 @@
+package data
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCSVLoader(t *testing.T) {
+	text := "a;b\n1;'x;y'\n"
+	l := NewCSVLoader(strings.NewReader(text), ';', '\'')
+
+	tests := []struct {
+		value string
+		path  []string
+	}{
+		{"a", []string{"1", "1"}},
+		{"b", []string{"1", "2"}},
+		{"1", []string{"2", "1"}},
+		{"x;y", []string{"2", "2"}},
+	}
+
+	for i, tt := range tests {
+		entry, err := l.Next()
+		if err != nil {
+			t.Fatalf("unexpected error on entry %d: %v", i, err)
+		}
+		if entry.Value != tt.value {
+			t.Fatalf("entry %d value = %q, want %q", i, entry.Value, tt.value)
+		}
+		if !reflect.DeepEqual(entry.Path, tt.path) {
+			t.Fatalf("entry %d path = %v, want %v", i, entry.Path, tt.path)
+		}
+	}
+
+	if _, err := l.Next(); err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- support CSV files via new `CSVLoader` with configurable delimiter and quote characters
- extend CLI `-ext` flag to accept delimiter and quote settings and instantiate proper loaders
- ensure default CSV handling in application wiring and test new loader

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c46ebafd5083339c06fa3ad33cd0a8